### PR TITLE
access registers with PT_REGS macros & add LINUX_ARCH flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,15 @@ EXTRA_CFLAGS ?= -O2 -mcpu=v1 -nostdinc -Wno-pointer-sign
 
 BPFHEADER = -I./kern \
 
+# Target Arch
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+   LINUX_ARCH = x86
+endif
+ifeq ($(UNAME_M),aarch64)
+   LINUX_ARCH = arm64
+endif
+
 all: $(KERN_OBJECTS) assets build
 	@echo $(shell date)
 
@@ -50,7 +59,8 @@ clean:
 	rm -f bin/ecapture
 
 $(KERN_OBJECTS): %.o: %.c
-	$(CLANG) $(EXTRA_CFLAGS) \
+	$(CLANG) -D__TARGET_ARCH_$(LINUX_ARCH) \
+		$(EXTRA_CFLAGS) \
 		$(BPFHEADER) \
 		-target bpfel -c $< -o $(subst kern/,user/bytecode/,$@) \
 		-fno-ident -fdebug-compilation-dir . -g -D__BPF_TARGET_MISSING="GCC error \"The eBPF is using target specific macros, please provide -target\"" \

--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -29,7 +29,7 @@ int uretprobe_bash_readline(struct pt_regs *ctx) {
     struct event event;
     //    bpf_printk("!! uretprobe_bash_readline pid:%d",target_pid );
     event.pid = bpf_get_current_pid_tgid();
-    bpf_probe_read(&event.line, sizeof(event.line), (void *)(ctx)->ax);
+    bpf_probe_read(&event.line, sizeof(event.line), (void *)PT_REGS_RC(ctx));
 
     bpf_get_current_comm(&event.comm, sizeof(event.comm));
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));

--- a/kern/gnutls_kern.c
+++ b/kern/gnutls_kern.c
@@ -83,7 +83,7 @@ static __inline struct ssl_data_event_t* create_ssl_data_event(uint64_t current_
 
 static int process_SSL_data(struct pt_regs* ctx, uint64_t id, enum ssl_data_event_type type,
                             const char* buf) {
-    int len = (int)(ctx)->ax;
+    int len = (int)PT_REGS_RC(ctx);
     if (len < 0) {
         return 0;
     }
@@ -120,7 +120,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         return 0;
     }
 
-    const char* buf = (const char*)(ctx)->si;
+    const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_write_args_map, &current_pid_tgid, &buf, BPF_ANY);
     return 0;
 }
@@ -157,7 +157,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
         return 0;
     }
 
-    const char* buf = (const char*)(ctx)->si;
+    const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_read_args_map, &current_pid_tgid, &buf, BPF_ANY);
     return 0;
 }

--- a/kern/mysqld56_kern.c
+++ b/kern/mysqld56_kern.c
@@ -31,7 +31,7 @@ int mysql56_query(struct pt_regs *ctx) {
     // https://blog.csdn.net/u010502974/article/details/96362601
     //mysql_parse
     // TODO change to macros
-    uint64_t command  = (uint64_t) (ctx)->di;
+    uint64_t command  = (uint64_t)PT_REGS_PARM1(ctx);
     if (command != COM_QUERY) {
         return 0;
     }
@@ -44,7 +44,7 @@ int mysql56_query(struct pt_regs *ctx) {
         return 0;
     }
 
-    uint64_t len  = (uint64_t) (ctx)->cx;
+    uint64_t len  = (uint64_t)PT_REGS_PARM1(ctx);
     if (len < 0) {
         return 0;
     }
@@ -58,7 +58,7 @@ int mysql56_query(struct pt_regs *ctx) {
     data.len = len;   // only process id
     bpf_get_current_comm(&data.comm, sizeof(data.comm));
 
-    bpf_probe_read_user(&data.query, len, (void*) (ctx)->dx);
+    bpf_probe_read_user(&data.query, len, (void*)PT_REGS_PARM3(ctx));
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &data,sizeof(data));
     return 0;
 }

--- a/kern/mysqld56_kern.c
+++ b/kern/mysqld56_kern.c
@@ -44,7 +44,7 @@ int mysql56_query(struct pt_regs *ctx) {
         return 0;
     }
 
-    uint64_t len  = (uint64_t)PT_REGS_PARM1(ctx);
+    uint64_t len  = (uint64_t)PT_REGS_PARM4(ctx);
     if (len < 0) {
         return 0;
     }

--- a/kern/nspr_kern.c
+++ b/kern/nspr_kern.c
@@ -75,7 +75,7 @@ static __inline struct ssl_data_event_t* create_ssl_data_event(uint64_t current_
 
 static int process_SSL_data(struct pt_regs* ctx, uint64_t id, enum ssl_data_event_type type,
                             const char* buf) {
-    int len = (int)(ctx)->ax;
+    int len = (int)PT_REGS_RC(ctx);
     if (len < 0) {
         return 0;
     }
@@ -111,7 +111,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         return 0;
     }
 
-    const char* buf = (const char*)(ctx)->si;
+    const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_write_args_map, &current_pid_tgid, &buf, BPF_ANY);
     return 0;
 }
@@ -149,7 +149,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
         return 0;
     }
 
-    const char* buf = (const char*)(ctx)->si;
+    const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_read_args_map, &current_pid_tgid, &buf, BPF_ANY);
     return 0;
 }


### PR DESCRIPTION
access registers with PT_REGS macros and add LINUX_ARCH flags to makefile.