### PR TITLE
feat: provide a docker image for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:21.04
+
+LABEL maintainer="Wenhao Jiang <whjiang1997@gmail.com>"
+
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV GOLANG_VERSION 1.16
+
+# install dependencies
+RUN set -x && \ 
+    apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+            wget \
+            make \
+            clang-12 \
+            pkg-config \
+            ca-certificates \
+            ; \
+            rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    update-alternatives --install \
+    /usr/bin/clang clang /usr/bin/clang-12 1\
+    --slave /usr/bin/clang++ clang++ /usr/bin/clang++-12 \
+    ;
+
+# install golang
+RUN set -eux; \
+    url='https://dl.google.com/go/go1.16.linux-amd64.tar.gz'; \
+    wget -O go.tgz "$url" --progress=dot:giga;\
+    tar -C /usr/local -xzf go.tgz; \
+    rm go.tgz; \
+    go version
+
+
+WORKDIR /mnt
+
+CMD [ "make" ]

--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,13 @@ assets:
 build:
 	CGO_ENABLED=0 go build -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=$(VERSION)'" -o bin/ecapture .
 
+
+DOCKER_NAME ?= ecapture-build:v1
+
+# build by docker
+build_docker:
+	docker run --mount type=bind,source=$(shell pwd),destination=/mnt ${DOCKER_NAME}
+
+# provide a standard enviroment for build
+docker: 
+	docker build -t ${DOCKER_NAME} .


### PR DESCRIPTION
1. Developer don't need install dependencies of build in dev machine.
2. Mount the source dir on container, the compiled products will generate to "/bin".