### PR TITLE
fix: use sudo command in clang command that maybe user may not root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ clean:
 	rm -f bin/ecapture
 
 $(KERN_OBJECTS): %.o: %.c
-	$(CLANG) -D__TARGET_ARCH_$(LINUX_ARCH) \
+	sudo $(CLANG) -D__TARGET_ARCH_$(LINUX_ARCH) \
 		$(EXTRA_CFLAGS) \
 		$(BPFHEADER) \
 		-target bpfel -c $< -o $(subst kern/,user/bytecode/,$@) \


### PR DESCRIPTION
why this change:

if user not root  old make need to `sudo make`
but only `clang` command  line need to use sudo

when use `sudo make`
If user in China behind `GFW` go proxy will not.use the `go env` proxy may caused the `network can not dial` problem

so I add `sudo` before clang that easily use in China...somehow.
