### PR TITLE
support no co-re version on linux kernel >= 5.2 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ CMD_MD5 ?= md5sum
 
 EXTRA_CFLAGS ?= -O2 -mcpu=v1 \
 	-DDEBUG_PRINT	\
-	-DCORE	\
 	-nostdinc \
 	-Wno-pointer-sign
 

--- a/Makefile.nocore
+++ b/Makefile.nocore
@@ -41,11 +41,23 @@ CMD_MD5 ?= md5sum
 	fi
 
 
-EXTRA_CFLAGS ?= -O2 -mcpu=v1 \
-	-DDEBUG_PRINT	\
-	-DCORE	\
-	-nostdinc \
-	-Wno-pointer-sign
+EXTRA_CFLAGS ?= -emit-llvm -O2 -S\
+	-Wunused \
+	-Wall \
+	-Wno-frame-address \
+	-Wno-unused-value \
+	-Wno-unknown-warning-option \
+	-Wno-pragma-once-outside-header \
+	-Wno-pointer-sign \
+	-Wno-gnu-variable-sized-type-not-at-end \
+	-Wno-deprecated-declarations \
+	-Wno-compare-distinct-pointer-types \
+	-Wno-address-of-packed-member \
+	-fno-stack-protector \
+	-fno-jump-tables \
+	-fno-unwind-tables \
+	-fno-asynchronous-unwind-tables \
+	-xc -O2 -g \
 
 BPFHEADER = -I./kern \
 
@@ -222,12 +234,28 @@ clean:
 $(KERN_OBJECTS): %.o: %.c \
 	| .checkver_$(CMD_CLANG) \
 	.checkver_$(CMD_GO)
-	$(CMD_CLANG) -D__TARGET_ARCH_$(LINUX_ARCH) \
-		$(EXTRA_CFLAGS) \
+	$(CMD_CLANG) \
+		-emit-llvm -S \
+		-D__BPF_TRACING__ \
+		-D__KERNEL__ \
+		-DNOCORE \
 		$(BPFHEADER) \
-		-target bpfel -c $< -o $(subst kern/,user/bytecode/,$@) \
-		-fno-ident -fdebug-compilation-dir . -g -D__BPF_TARGET_MISSING="GCC error \"The eBPF is using target specific macros, please provide -target\"" \
-		-MD -MP
+		-include $(KERN_SRC_PATH)/include/linux/kconfig.h \
+		-I $(KERN_SRC_PATH)/arch/$(LINUX_ARCH)/include \
+		-I $(KERN_SRC_PATH)/arch/$(LINUX_ARCH)/include/uapi \
+		-I $(KERN_BUILD_PATH)/arch/$(LINUX_ARCH)/include/generated \
+		-I $(KERN_BUILD_PATH)/arch/$(LINUX_ARCH)/include/generated/uapi \
+		-I $(KERN_SRC_PATH)/include \
+		-I $(KERN_BUILD_PATH)/include \
+		-I $(KERN_SRC_PATH)/include/uapi \
+		-I $(KERN_BUILD_PATH)/include/generated \
+		-I $(KERN_BUILD_PATH)/include/generated/uapi \
+		$(EXTRA_CFLAGS) \
+		-c $< \
+		-o - |$(CMD_LLC) \
+		-march=bpf \
+		-filetype=obj \
+		-o $(subst kern/,user/bytecode/,$(subst .c,.o,$<))
 
 .PHONY: ebpf
 ebpf: $(KERN_OBJECTS)
@@ -243,4 +271,4 @@ assets: \
 build: \
 	.checkver_$(CMD_GO)
 #
-	CGO_ENABLED=0 $(CMD_GO) build -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=$(VERSION)'" -o bin/ecapture .
+	CGO_ENABLED=0 $(CMD_GO) build -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=[*NOCORE*]_$(VERSION)' -X 'main.enableCORE=false'" -o bin/ecapture .

--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -1,6 +1,4 @@
-#include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include "core_type.h"
 #include "common.h"
 
 struct event {

--- a/kern/common.h
+++ b/kern/common.h
@@ -1,8 +1,6 @@
 #ifndef ECAPTURE_COMMON_H
 #define ECAPTURE_COMMON_H
 
-//#define DEBUG_PRINT true
-
 #ifdef DEBUG_PRINT
 #define debug_bpf_printk(fmt, ...)					\
 	do {							\

--- a/kern/core_type.h
+++ b/kern/core_type.h
@@ -1,13 +1,13 @@
-#ifndef CORE
+#ifndef NOCORE
+//CO:RE is enabled
+#include "vmlinux.h"
+#include "bpf/bpf_helpers.h"
+#include "bpf/bpf_tracing.h"
+
+#else
 #include <uapi/linux/ptrace.h>
 #include <linux/bpf.h>
 #include <linux/socket.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
-
-#else
-//CO:RE is enabled
-#include "vmlinux.h"
-#include "bpf/bpf_helpers.h"
-#include "bpf/bpf_tracing.h"
 #endif

--- a/kern/core_type.h
+++ b/kern/core_type.h
@@ -1,0 +1,13 @@
+#ifndef CORE
+#include <uapi/linux/ptrace.h>
+#include <linux/bpf.h>
+#include <linux/socket.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#else
+//CO:RE is enabled
+#include "vmlinux.h"
+#include "bpf/bpf_helpers.h"
+#include "bpf/bpf_tracing.h"
+#endif

--- a/kern/gnutls_kern.c
+++ b/kern/gnutls_kern.c
@@ -1,6 +1,4 @@
-#include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include "core_type.h"
 #include "common.h"
 
 

--- a/kern/mysqld_kern.c
+++ b/kern/mysqld_kern.c
@@ -1,6 +1,4 @@
-#include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include "core_type.h"
 #include "common.h"
 
 struct data_t {

--- a/kern/nspr_kern.c
+++ b/kern/nspr_kern.c
@@ -1,6 +1,4 @@
-#include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include "core_type.h"
 #include "common.h"
 
 enum ssl_data_event_type { kSSLRead, kSSLWrite };

--- a/kern/openssl_kern.c
+++ b/kern/openssl_kern.c
@@ -1,6 +1,4 @@
-#include "vmlinux.h"
-#include <bpf/bpf_helpers.h>
-#include <bpf/bpf_tracing.h>
+#include "core_type.h"
 #include "common.h"
 
 enum ssl_data_event_type { kSSLRead, kSSLWrite };

--- a/main.go
+++ b/main.go
@@ -7,6 +7,10 @@ import (
 	"log"
 )
 
+var (
+	enableCORE = "true"
+)
+
 func main() {
 
 	// 环境检测
@@ -19,13 +23,16 @@ func main() {
 		log.Fatalf("Linux Kernel version %v is not supported. Need > 4.18 .", kv)
 	}
 
-	// BTF支持情况检测
-	enable, e := ebpf.IsEnableBTF()
-	if e != nil {
-		log.Fatal(err)
-	}
-	if !enable {
-		log.Fatal("BTF not support, please check it. shell: cat /boot/config-`uname -r` | grep CONFIG_DEBUG_INFO_BTF ")
+	// changed by go build '-ldflags X'
+	if enableCORE == "ture" {
+		// BTF支持情况检测
+		enable, e := ebpf.IsEnableBTF()
+		if e != nil {
+			log.Fatal(err)
+		}
+		if !enable {
+			log.Fatal("BTF not support, please check it. shell: cat /boot/config-`uname -r` | grep CONFIG_DEBUG_INFO_BTF ")
+		}
 	}
 
 	cli.Start()


### PR DESCRIPTION
fix  #31 
1. add Makefile.nocore
2. support no co-re with linux headers by KERN_SRC_PATH.

Signed-off-by: CFC4N <cfc4n.cs@gmail.com>