### PR TITLE
* : Fix #39 .rodata: map create: read- and write-only maps not supported (requires >= v5.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ EXTRA_CFLAGS_NOCORE ?= -emit-llvm -O2 -S\
 	-D__KERNEL__ \
 	-DNOCORE \
 	$(DEBUG_PRINT) \
-	-Wunused \
 	-Wall \
+	-Wno-unused-variable \
 	-Wno-frame-address \
 	-Wno-unused-value \
 	-Wno-unknown-warning-option \
@@ -140,6 +140,24 @@ VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(LAST_GIT_TAG))
 
 UNAME_M := $(shell uname -m)
 UNAME_R := $(shell uname -r)
+
+
+#
+# Kernel Version detect
+#
+
+KERNEL_LESS_5_2_FLAGS ?=
+KERNEL_LESS_VERSION := 5.2.0
+HIGHER_VERSION := $(shell echo -e "$(UNAME_R)\n$(KERNEL_LESS_VERSION)" | sort -V | tail --lines=1)
+
+# kernel version compare
+ifeq ($(HIGHER_VERSION),$(KERNEL_LESS_VERSION))
+   # its an older kernel
+   KERNEL_LESS_5_2_FLAGS = -DKERNEL_LESS_5_2
+else
+  # its a newer kernel
+endif
+
 
 #
 # Target Arch
@@ -302,6 +320,7 @@ $(KERN_OBJECTS_NOCORE): %.nocore: %.c \
     		-I $(KERN_BUILD_PATH)/include/generated \
     		-I $(KERN_BUILD_PATH)/include/generated/uapi \
     		$(EXTRA_CFLAGS_NOCORE) \
+    		$(KERNEL_LESS_5_2_FLAGS) \
     		-c $< \
     		-o - |$(CMD_LLC) \
     		-march=bpf \

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ build: \
 build_nocore: \
 	.checkver_$(CMD_GO)
 #
-	CGO_ENABLED=0 $(CMD_GO) build -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=[NO_CO_RE]:$(VERSION)' -X 'main.enableCORE=false' -X 'user.enableCORE=false'" -o bin/ecapture .
+	CGO_ENABLED=0 $(CMD_GO) build -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=[NO_CO_RE]:$(VERSION)' -X 'main.enableCORE=false'" -o bin/ecapture .
 
 
 .PHONY: ebpf_nocore

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -90,14 +90,14 @@ func openSSLCommandFunc(command *cobra.Command, args []string) {
 
 		if e := conf.Check(); e != nil {
 			logger.Printf("%v", e)
-			break
+			continue
 		}
 
 		//初始化
 		err := mod.Init(ctx, logger, conf)
 		if err != nil {
 			logger.Printf("%v", err)
-			break
+			continue
 		}
 
 		// 加载ebpf，挂载到hook点上，开始监听

--- a/kern/README.md
+++ b/kern/README.md
@@ -1,6 +1,6 @@
 # application source doc.
 
-## openssl
+## openssl 1.1.*
 ### version
 * define SSL3_VERSION                    0x0300
 * define TLS1_VERSION                    0x0301
@@ -55,5 +55,63 @@ struct bio_st {
     uint64_t num_write;
     CRYPTO_EX_DATA ex_data;
     CRYPTO_RWLOCK *lock;
+};
+```
+
+
+## openssl  1.0.*
+https://github.com/openssl/openssl/blob/OpenSSL_1_0_0-stable/ssl/ssl.h#L1093
+```c
+struct ssl_st {
+    /*
+     * protocol version (one of SSL2_VERSION, SSL3_VERSION, TLS1_VERSION,
+     * DTLS1_VERSION)
+     */
+    int version;
+    /* SSL_ST_CONNECT or SSL_ST_ACCEPT */
+    int type;
+    /* SSLv3 */
+    const SSL_METHOD *method;
+    /*
+     * There are 2 BIO's even though they are normally both the same.  This
+     * is so data can be read and written to different handlers
+     */
+# ifndef OPENSSL_NO_BIO
+    /* used by SSL_read */
+    BIO *rbio;
+    /* used by SSL_write */
+    BIO *wbio;
+    /* used during session-id reuse to concatenate messages */
+    BIO *bbio;
+# else
+    /* used by SSL_read */
+    char *rbio;
+    /* used by SSL_write */
+    char *wbio;
+    char *bbio;
+# endif
+    /*
+```
+
+
+https://github.com/openssl/openssl/blob/OpenSSL_1_0_0-stable/crypto/bio/bio.h
+```c
+struct bio_st {
+    BIO_METHOD *method;
+    /* bio, mode, argp, argi, argl, ret */
+    long (*callback) (struct bio_st *, int, const char *, int, long, long);
+    char *cb_arg;               /* first argument for the callback */
+    int init;
+    int shutdown;
+    int flags;                  /* extra storage */
+    int retry_reason;
+    int num;
+    void *ptr;
+    struct bio_st *next_bio;    /* used by filter BIOs */
+    struct bio_st *prev_bio;    /* used by filter BIOs */
+    int references;
+    unsigned long num_read;
+    unsigned long num_write;
+    CRYPTO_EX_DATA ex_data;
 };
 ```

--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -16,17 +16,19 @@ const struct event *unused __attribute__((unused));
 
 SEC("uretprobe/bash_readline")
 int uretprobe_bash_readline(struct pt_regs *ctx) {
-    size_t pid_tgid = bpf_get_current_pid_tgid();
+    s64 pid_tgid = bpf_get_current_pid_tgid();
     int pid = pid_tgid >> 32;
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     struct event event;
     //    bpf_printk("!! uretprobe_bash_readline pid:%d",target_pid );
-    event.pid = bpf_get_current_pid_tgid();
+    event.pid = pid;
     bpf_probe_read(&event.line, sizeof(event.line), (void *)PT_REGS_RC(ctx));
 
     bpf_get_current_comm(&event.comm, sizeof(event.comm));

--- a/kern/common.h
+++ b/kern/common.h
@@ -21,10 +21,11 @@
 #define SA_DATA_LEN 14
 
 // Optional Target PID
-#ifdef NOCORE
-u64 target_pid = 0;
-#else
+// .rodata section bug via : https://github.com/ehids/ecapture/issues/39
+#ifndef KERNEL_LESS_5_2
 const volatile u64 target_pid = 0;
+#else
+//u64 target_pid = 0;
 #endif
 
 char __license[] SEC("license") = "Dual MIT/GPL";

--- a/kern/gnutls_kern.c
+++ b/kern/gnutls_kern.c
@@ -112,11 +112,14 @@ SEC("uprobe/gnutls_record_send")
 int probe_entry_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("gnutls uprobe/gnutls_record_send pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_write_args_map, &current_pid_tgid, &buf, BPF_ANY);
@@ -127,11 +130,14 @@ SEC("uretprobe/gnutls_record_send")
 int probe_ret_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("gnutls uretprobe/gnutls_record_send pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char** buf = bpf_map_lookup_elem(&active_ssl_write_args_map, &current_pid_tgid);
     if (buf != NULL) {
@@ -149,11 +155,15 @@ SEC("uprobe/gnutls_record_recv")
 int probe_entry_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("gnutls uprobe/gnutls_record_recv pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_read_args_map, &current_pid_tgid, &buf, BPF_ANY);
@@ -164,11 +174,14 @@ SEC("uretprobe/gnutls_record_recv")
 int probe_ret_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("gnutls uretprobe/gnutls_record_recv pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char** buf = bpf_map_lookup_elem(&active_ssl_read_args_map, &current_pid_tgid);
     if (buf != NULL) {

--- a/kern/mysqld_kern.c
+++ b/kern/mysqld_kern.c
@@ -37,10 +37,12 @@ int mysql56_query(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     u64 len  = (u64)PT_REGS_PARM4(ctx);
     if (len < 0) {
@@ -115,10 +117,12 @@ int mysql57_query(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     u64 len  = 0;
     struct data_t data = {};

--- a/kern/nspr_kern.c
+++ b/kern/nspr_kern.c
@@ -103,11 +103,14 @@ SEC("uprobe/PR_Write")
 int probe_entry_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("nspr uprobe/PR_Write pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_write_args_map, &current_pid_tgid, &buf, BPF_ANY);
@@ -118,11 +121,14 @@ SEC("uretprobe/PR_Write")
 int probe_ret_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("nspr uretprobe/PR_Write pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char** buf = bpf_map_lookup_elem(&active_ssl_write_args_map, &current_pid_tgid);
     if (buf != NULL) {
@@ -141,11 +147,14 @@ SEC("uprobe/PR_Read")
 int probe_entry_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("nspr uprobe/PR_Read pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&active_ssl_read_args_map, &current_pid_tgid, &buf, BPF_ANY);
@@ -156,11 +165,14 @@ SEC("uretprobe/PR_Read")
 int probe_ret_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("nspr uretprobe/PR_Read pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     const char** buf = bpf_map_lookup_elem(&active_ssl_read_args_map, &current_pid_tgid);
     if (buf != NULL) {

--- a/kern/openssl_kern.c
+++ b/kern/openssl_kern.c
@@ -154,10 +154,13 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
+    debug_bpf_printk("openssl uprobe/SSL_write pid :%d\n", pid);
 
     void * ssl = (void *) PT_REGS_PARM1(ctx);
     // https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/bio/bio_local.h
@@ -169,7 +172,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
 
     // get fd ssl->wbio->num
     u32 fd = bio_w.num;
-    debug_bpf_printk("uprobe SSL_write FD:%d\n", fd);
+    debug_bpf_printk("openssl uprobe SSL_write FD:%d\n", fd);
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     struct active_ssl_buf active_ssl_buf_t;
@@ -186,11 +189,13 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
-
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
+    debug_bpf_printk("openssl uretprobe/SSL_write pid :%d\n", pid);
     struct active_ssl_buf* active_ssl_buf_t = bpf_map_lookup_elem(&active_ssl_write_args_map, &current_pid_tgid);
     if (active_ssl_buf_t != NULL) {
         const char* buf;
@@ -208,11 +213,14 @@ SEC("uprobe/SSL_read")
 int probe_entry_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("openssl uprobe/SSL_read pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     void * ssl = (void *) PT_REGS_PARM1(ctx);
     // https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/bio/bio_local.h
@@ -224,7 +232,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
 
     // get fd ssl->rbio->num
     u32 fd = bio_r.num;
-    debug_bpf_printk("uprobe SSL_read FD:%d\n", fd);
+    debug_bpf_printk("openssl uprobe PID:%d, SSL_read FD:%d\n",pid,  fd);
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     struct active_ssl_buf active_ssl_buf_t;
@@ -239,11 +247,14 @@ SEC("uretprobe/SSL_read")
 int probe_ret_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    debug_bpf_printk("openssl uretprobe/SSL_read pid :%d\n", pid);
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     struct active_ssl_buf* active_ssl_buf_t = bpf_map_lookup_elem(&active_ssl_read_args_map, &current_pid_tgid);
     if (active_ssl_buf_t != NULL) {
@@ -264,10 +275,12 @@ int probe_connect(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
 
-    // if target_ppid is 0 then we target all pids
-    if (target_pid != 0 && target_pid != pid) {
-        return 0;
-    }
+    #ifndef KERNEL_LESS_5_2
+        // if target_ppid is 0 then we target all pids
+        if (target_pid != 0 && target_pid != pid) {
+            return 0;
+        }
+    #endif
 
     u32 fd = (u32)PT_REGS_PARM1(ctx);
     struct sockaddr *saddr = (struct sockaddr *)PT_REGS_PARM2(ctx);

--- a/user/config_nspr.go
+++ b/user/config_nspr.go
@@ -43,10 +43,10 @@ func (this *NsprConfig) Check() error {
 		}
 	} else {
 		//如果没配置，则直接指定。
-		this.Nsprpath = "/usr/lib/firefox/firefox"
+		this.Firefoxpath = "/usr/lib/firefox/firefox"
 	}
 
-	soPath, e := getDynPathByElf(this.Nsprpath, "libnspr4.so")
+	soPath, e := getDynPathByElf(this.Firefoxpath, "libnspr4.so")
 	if e != nil {
 		//this.logger.Printf("get bash:%s dynamic library error:%v.\n", bash, e)
 		_, e = os.Stat(X86_BINARY_PREFIX)

--- a/user/event_nspr.go
+++ b/user/event_nspr.go
@@ -66,7 +66,8 @@ func (this *NsprDataEvent) StringHex() string {
 	// firefox 进程的通讯线程名为 Socket Thread ，过滤 TODO
 	var fire_thread string
 	fire_thread = strings.TrimSpace(fmt.Sprintf("%s", this.Comm[:13]))
-	if strings.Compare(fire_thread, "Socket Thread") != 0 {
+	// disable filter default
+	if false && strings.Compare(fire_thread, "Socket Thread") != 0 {
 		b = bytes.NewBufferString(fmt.Sprintf("%s[ignore]%s", COLORBLUE, COLORRESET))
 		s = fmt.Sprintf("PID:%d, Comm:%s, Type:%s, TID:%d, DataLen:%d bytes, Payload:%s", this.Pid, this.Comm, packetType, this.Tid, this.Data_len, b.String())
 	} else {
@@ -93,7 +94,8 @@ func (this *NsprDataEvent) String() string {
 
 	var b *bytes.Buffer
 	// firefox 进程的通讯线程名为 Socket Thread ，过滤 TODO
-	if strings.TrimSpace(string(this.Comm[:13])) != "Socket Thread" {
+	// disable filter default
+	if false && strings.TrimSpace(string(this.Comm[:13])) != "Socket Thread" {
 		b = bytes.NewBufferString("[ignore]")
 	} else {
 		b = bytes.NewBuffer(this.Data[:this.Data_len])

--- a/user/iconfig.go
+++ b/user/iconfig.go
@@ -4,9 +4,7 @@ Copyright © 2022 CFC4N <cfc4n.cs@gmail.com>
 */
 package user
 
-var (
-	enableCORE = "true"
-)
+import "ecapture/pkg/util/kernel"
 
 type IConfig interface {
 	Check() error //检测配置合法性
@@ -16,7 +14,7 @@ type IConfig interface {
 	SetPid(uint64)
 	SetHex(bool)
 	SetDebug(bool)
-	EnableCoRe() bool //
+	EnableGlobalVar() bool //
 }
 
 type eConfig struct {
@@ -49,10 +47,15 @@ func (this *eConfig) SetHex(isHex bool) {
 	this.IsHex = isHex
 }
 
-func (this *eConfig) EnableCoRe() bool {
-	if enableCORE == "true" {
+func (this *eConfig) EnableGlobalVar() bool {
+	kv, err := kernel.HostVersion()
+	if err != nil {
+		//log.Fatal(err)
 		return true
-	} else {
+	}
+	if kv < kernel.VersionCode(5, 2, 0) {
+		//log.Fatalf("Linux Kernel version %v is not supported. Need > 4.18 .", kv)
 		return false
 	}
+	return true
 }

--- a/user/probe_bash.go
+++ b/user/probe_bash.go
@@ -139,7 +139,7 @@ func (this *MBashProbe) setupManagers() {
 		},
 	}
 
-	if this.conf.EnableCoRe() {
+	if this.conf.EnableGlobalVar() {
 		// 填充 RewriteContants 对应map
 		this.bpfManagerOptions.ConstantEditors = this.constantEditor()
 	}

--- a/user/probe_gnutls.go
+++ b/user/probe_gnutls.go
@@ -166,7 +166,7 @@ func (this *MGnutlsProbe) setupManagers() error {
 		},
 	}
 
-	if this.conf.EnableCoRe() {
+	if this.conf.EnableGlobalVar() {
 		// 填充 RewriteContants 对应map
 		this.bpfManagerOptions.ConstantEditors = this.constantEditor()
 	}

--- a/user/probe_nspr.go
+++ b/user/probe_nspr.go
@@ -132,6 +132,8 @@ func (this *MNsprProbe) setupManagers() error {
 			},
 
 			// for PR_Send start
+			//  |  ``PR_Send`` or ``PR_Write``
+			//   | ``PR_Read`` or ``PR_Recv``
 			{
 				UID:              "PR_Write-PR_Send",
 				Section:          "uprobe/PR_Write",
@@ -199,7 +201,7 @@ func (this *MNsprProbe) setupManagers() error {
 		},
 	}
 
-	if this.conf.EnableCoRe() {
+	if this.conf.EnableGlobalVar() {
 		// 填充 RewriteContants 对应map
 		this.bpfManagerOptions.ConstantEditors = this.constantEditor()
 	}

--- a/user/probe_openssl.go
+++ b/user/probe_openssl.go
@@ -186,7 +186,7 @@ func (this *MOpenSSLProbe) setupManagers() error {
 		},
 	}
 
-	if this.conf.EnableCoRe() {
+	if this.conf.EnableGlobalVar() {
 		// 填充 RewriteContants 对应map
 		this.bpfManagerOptions.ConstantEditors = this.constantEditor()
 	}


### PR DESCRIPTION
1,global variable declaration will compile to .rodata/.bss section in ELF file.
2, haveMapMutabilityModifiers variable will create `ARRAY` type ebpf map with `BPF_F_RDONLY_PROG` flag to detect system supported in syscalls.go .
3. so need to remove global variable on kernel version less than 5.2 via haveMapMutabilityModifiers in cilium/ebpf/syscalls.go
4. more info https://github.com/cilium/ebpf/commit/f5942f5215490ef5f1bc2072f2c925ce7712a20e

Signed-off-by: CFC4N <cfc4n.cs@gmail.com>