### PR TITLE
change bash line size to 256 bytes

### DIFF
--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -2,7 +2,7 @@
 
 struct event {
     u32 pid;
-    u8 line[80];
+    u8 line[MAX_DATA_SIZE_BASH];
     u32 retval;
     char comm[TASK_COMM_LEN];
 };

--- a/kern/common.h
+++ b/kern/common.h
@@ -15,6 +15,7 @@
 #define MAX_DATA_SIZE_OPENSSL 1024 * 4
 #define MAX_DATA_SIZE_MYSQL 256
 #define MAX_DATA_SIZE_POSTGRES 256
+#define MAX_DATA_SIZE_BASH 256
 
 // enum_server_command, via
 // https://dev.mysql.com/doc/internals/en/com-query.html COM_QUERT command 03

--- a/user/event_bash.go
+++ b/user/event_bash.go
@@ -8,10 +8,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+/*
+ u32 pid;
+ u8 line[MAX_DATE_SIZE_BASH];
+ u32 retval;
+ char comm[TASK_COMM_LEN];
+*/
+
+const MAX_DATA_SIZE_BASH = 256
+
 type bashEvent struct {
 	module IModule
 	Pid    uint32
-	Line   [80]uint8
+	Line   [MAX_DATA_SIZE_BASH]uint8
 	Retval uint32
 	Comm   [16]byte
 }


### PR DESCRIPTION
**bash监控中遇到诸如:wget、curl场景时，默认命令长度80相对较短**
如下述命令
`wget https://support.asiainfo-sec.com/TM-Product/Product/Deep_Security/DS_for_Multi_Hypervisor/10.5_MH/DSA/Agent-RedHat_EL7-10.5.0-3336.x86_64.zip`
因此针对一般情况，修改line长度到256字节

**存在问题**
修改到256依旧无法满足超长命令情况（如更长的url), 不过一般情况下应该可以满足需求