### PR TITLE
Add nosearch argument to skip auto search lib path

### DIFF
--- a/cli/cmd/global.go
+++ b/cli/cmd/global.go
@@ -11,9 +11,10 @@ import (
 // GlobalFlags are flags that defined globally
 // and are inherited to all sub-commands.
 type GlobalFlags struct {
-	IsHex bool
-	Debug bool
-	Pid   uint64 // PID
+	IsHex    bool
+	Debug    bool
+	Pid      uint64 // PID
+	NoSearch bool   // No lib search
 }
 
 func getGlobalConf(command *cobra.Command) (conf GlobalFlags, err error) {
@@ -28,6 +29,11 @@ func getGlobalConf(command *cobra.Command) (conf GlobalFlags, err error) {
 	}
 
 	conf.IsHex, err = command.Flags().GetBool("hex")
+	if err != nil {
+		return
+	}
+
+	conf.NoSearch, err = command.Flags().GetBool("nosearch")
 	if err != nil {
 		return
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -73,5 +73,6 @@ func init() {
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Debug, "debug", "d", false, "enable debug logging")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.IsHex, "hex", false, "print byte strings as hex encoded strings")
+	rootCmd.PersistentFlags().BoolVar(&globalFlags.NoSearch, "nosearch", false, "no lib search")
 	rootCmd.PersistentFlags().Uint64VarP(&globalFlags.Pid, "pid", "p", defaultPid, "if pid is 0 then we target all pids")
 }

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -87,6 +87,7 @@ func openSSLCommandFunc(command *cobra.Command, args []string) {
 		conf.SetPid(gConf.Pid)
 		conf.SetDebug(gConf.Debug)
 		conf.SetHex(gConf.IsHex)
+		conf.SetNoSearch(gConf.NoSearch)
 
 		if e := conf.Check(); e != nil {
 			logger.Printf("%v", e)

--- a/user/config_gnutls.go
+++ b/user/config_gnutls.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // 最终使用openssl参数
@@ -33,6 +35,10 @@ func (this *GnutlsConfig) Check() error {
 		}
 		this.elfType = ELF_TYPE_SO
 		return nil
+	}
+
+	if this.NoSearch {
+		return errors.New("NoSearch requires specifying lib path")
 	}
 
 	//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回

--- a/user/config_nspr.go
+++ b/user/config_nspr.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // 最终使用openssl参数
@@ -33,6 +35,10 @@ func (this *NsprConfig) Check() error {
 		}
 		this.elfType = ELF_TYPE_SO
 		return nil
+	}
+
+	if this.NoSearch {
+		return errors.New("NoSearch requires specifying lib path")
 	}
 
 	//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回

--- a/user/config_openssl.go
+++ b/user/config_openssl.go
@@ -63,6 +63,10 @@ func (this *OpensslConfig) Check() error {
 		return nil
 	}
 
+	if this.NoSearch {
+		return errors.New("NoSearch requires specifying lib path")
+	}
+
 	if !checkedOpenssl {
 		e := this.checkOpenssl()
 		if e != nil {

--- a/user/iconfig.go
+++ b/user/iconfig.go
@@ -11,16 +11,19 @@ type IConfig interface {
 	GetPid() uint64
 	GetHex() bool
 	GetDebug() bool
+	GetNoSearch() bool
 	SetPid(uint64)
 	SetHex(bool)
 	SetDebug(bool)
+	SetNoSearch(bool)
 	EnableGlobalVar() bool //
 }
 
 type eConfig struct {
-	Pid   uint64
-	IsHex bool
-	Debug bool
+	Pid      uint64
+	IsHex    bool
+	Debug    bool
+	NoSearch bool
 }
 
 func (this *eConfig) GetPid() uint64 {
@@ -35,6 +38,10 @@ func (this *eConfig) GetHex() bool {
 	return this.IsHex
 }
 
+func (this *eConfig) GetNoSearch() bool {
+	return this.NoSearch
+}
+
 func (this *eConfig) SetPid(pid uint64) {
 	this.Pid = pid
 }
@@ -45,6 +52,10 @@ func (this *eConfig) SetDebug(b bool) {
 
 func (this *eConfig) SetHex(isHex bool) {
 	this.IsHex = isHex
+}
+
+func (this *eConfig) SetNoSearch(noSearch bool) {
+	this.NoSearch = noSearch
 }
 
 func (this *eConfig) EnableGlobalVar() bool {


### PR DESCRIPTION
When run ecapture in Kubernetes pod, ecapture is given
--libssl, --pthread to specific lib location, but ecapture
continues to auto search gnutls lib and result in error

2022/06/05 16:46:48 pid info :3305486
2022/06/05 16:46:48 start to run EBPFProbeOPENSSL module
2022/06/05 16:46:48 start to run EBPFProbeGNUTLS module <====
2022/06/05 16:46:48 lstat /etc/ld.so.conf: no such file or directory <===
2022/06/05 16:46:48 invalid argument <====

see https://github.com/ehids/ecapture/issues/69

add nosearch argument to skip the auto search of tls libs when
in container that `/etc/ld.so.conf` and standard lib path like
` /lib64`, `/usr/lib64` do not exist

Signed-off-by: Vincent Li <vincent.mc.li@gmail.com>