### PR TITLE
Add --gover for stripped Go app

### DIFF
--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -40,6 +40,7 @@ func init() {
 	opensslCmd.PersistentFlags().StringVar(&nc.Nsprpath, "nspr", "", "libnspr44.so file path, will automatically find it from curl default.")
 	opensslCmd.PersistentFlags().StringVar(&oc.Pthread, "pthread", "", "libpthread.so file path, use to hook connect to capture socket FD.will automatically find it from curl.")
 	opensslCmd.PersistentFlags().StringVar(&goc.Path, "gobin", "", "path to binary built with Go toolchain.")
+	opensslCmd.PersistentFlags().StringVar(&goc.Gover, "gover", "", "Go version for stripped Go app binary.")
 
 	rootCmd.AddCommand(opensslCmd)
 }

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -62,7 +62,7 @@ func ExtraceGoVersion(path string) (*GoVersion, error) {
 				if !ok {
 					continue
 				}
-				return parseGoVersion(val)
+				return ParseGoVersion(val)
 			}
 		}
 	}
@@ -70,7 +70,7 @@ func ExtraceGoVersion(path string) (*GoVersion, error) {
 	return nil, ErrVersionNotFound
 }
 
-func parseGoVersion(r string) (*GoVersion, error) {
+func ParseGoVersion(r string) (*GoVersion, error) {
 	ver := strings.TrimPrefix(r, goVersionPrefix)
 
 	if strings.HasPrefix(ver, "go") {

--- a/user/config_gossl.go
+++ b/user/config_gossl.go
@@ -9,7 +9,8 @@ import (
 // GoSSLConfig represents configuration for Go SSL probe
 type GoSSLConfig struct {
 	eConfig
-	Path string
+	Path  string
+	Gover string
 }
 
 // NewGoSSLConfig creates a new config for Go SSL

--- a/user/probe_gossl.go
+++ b/user/probe_gossl.go
@@ -26,6 +26,7 @@ type GoSSLProbe struct {
 
 	mngr          *manager.Manager
 	path          string
+	gover         string
 	isRegisterABI bool
 }
 
@@ -33,10 +34,25 @@ func (p *GoSSLProbe) Init(ctx context.Context, l *log.Logger, cfg IConfig) error
 	p.Module.Init(ctx, l)
 	p.Module.SetChild(p)
 
+	var (
+		ver *proc.GoVersion
+		err error
+	)
+
 	p.path = cfg.(*GoSSLConfig).Path
-	ver, err := proc.ExtraceGoVersion(p.path)
-	if err != nil {
-		return err
+
+	if len(cfg.(*GoSSLConfig).Gover) > 0 {
+		p.gover = cfg.(*GoSSLConfig).Gover
+		ver, err = proc.ParseGoVersion(p.gover)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		ver, err = proc.ExtraceGoVersion(p.path)
+		if err != nil {
+			return err
+		}
 	}
 
 	if ver.After(1, 15) {


### PR DESCRIPTION
Stripped Go app contains no debug info and unable to
extract Go version from the Go app, add --gover to
workaround stripped Go app

Signed-off-by: Vincent Li <vincent.mc.li@gmail.com>