### PR TITLE
Fix: correct ssl_st member offsets

### DIFF
--- a/kern/masterkey_kern.h
+++ b/kern/masterkey_kern.h
@@ -77,26 +77,20 @@
     unsigned char early_exporter_master_secret[EVP_MAX_MD_SIZE];
 */
 
-// session->cipher 在 SSL_SESSION 中的偏移量
-#define CIPHER_OFFSET 0xEC
-
-// ssl_cipher_st-> id 在 ssl_cipher_st 中的偏移量
-#define CIPHER_ID_OFFSET 0x18
-
 // ssl->handshake_secret 在 ssl_st 中的偏移量
-#define HANDSHAKE_SECRET_OFFSET 0x13C  // 316
+#define HANDSHAKE_SECRET_OFFSET 0x17C  // 380
 
 // ssl->master_secret 在 ssl_st 中的偏移量
-#define MASTER_SECRET_OFFSET 0x17C  // 380
+#define MASTER_SECRET_OFFSET 0x1BC  // 444
 
 // ssl->server_finished_hash 在 ssl_st 中的偏移量
-#define SERVER_FINISHED_HASH_OFFSET 0x27C  // 636
+#define SERVER_FINISHED_HASH_OFFSET 0x2BC  // 700
 
 // ssl->handshake_traffic_hash 在 ssl_st 中的偏移量
-#define HANDSHAKE_TRAFFIC_HASH_OFFSET 0x2BC  // 700
+#define HANDSHAKE_TRAFFIC_HASH_OFFSET 0x2FC  // 764
 
 // ssl->exporter_master_secret 在 ssl_st 中的偏移量
-#define EXPORTER_MASTER_SECRET_OFFSET 0x37C  // 892
+#define EXPORTER_MASTER_SECRET_OFFSET 0x3BC  // 956
 
 struct mastersecret_t {
     // TLS 1.2 or older

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -506,7 +506,7 @@ func (this *MOpenSSLProbe) saveMasterSecret(secretEvent *event.MasterSecretEvent
 		b = bytes.NewBufferString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelClientHandshake, secretEvent.ClientRandom, clientSecret))
 
 		serverHandshakeSecret := hkdf.DeriveSecret(secretEvent.HandshakeSecret[:], hkdf.ServerHandshakeTrafficLabel, transcript)
-		b.WriteString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelClientHandshake, secretEvent.ClientRandom, serverHandshakeSecret))
+		b.WriteString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelServerHandshake, secretEvent.ClientRandom, serverHandshakeSecret))
 
 		transcript.Reset()
 		transcript.Write(secretEvent.ServerFinishedHash[:])

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -492,11 +492,10 @@ func (this *MOpenSSLProbe) saveMasterSecret(secretEvent *event.MasterSecretEvent
 		// check crypto type
 		switch uint16(secretEvent.CipherId & 0x0000FFFF) {
 		case hkdf.TLS_AES_128_GCM_SHA256:
+		case hkdf.TLS_CHACHA20_POLY1305_SHA256:
 			transcript = crypto.SHA256.New()
 		case hkdf.TLS_AES_256_GCM_SHA384:
 			transcript = crypto.SHA384.New()
-		case hkdf.TLS_CHACHA20_POLY1305_SHA256:
-			transcript = crypto.SHA256.New()
 		default:
 			this.logger.Printf("non-tls 1.3 ciphersuite in tls13_hkdf_expand, CipherId: %d", secretEvent.CipherId)
 			return

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -77,7 +77,7 @@ type MOpenSSLProbe struct {
 	tcPacketLocker    *sync.Mutex
 }
 
-//对象初始化
+// 对象初始化
 func (this *MOpenSSLProbe) Init(ctx context.Context, logger *log.Logger, conf config.IConfig) error {
 	this.Module.Init(ctx, logger)
 	this.conf = conf
@@ -197,7 +197,7 @@ func (this *MOpenSSLProbe) Close() error {
 	return this.Module.Close()
 }
 
-//  通过elf的常量替换方式传递数据
+// 通过elf的常量替换方式传递数据
 func (this *MOpenSSLProbe) constantEditor() []manager.ConstantEditor {
 	var editor = []manager.ConstantEditor{
 		{

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -491,8 +491,7 @@ func (this *MOpenSSLProbe) saveMasterSecret(secretEvent *event.MasterSecretEvent
 		var transcript hash.Hash
 		// check crypto type
 		switch uint16(secretEvent.CipherId & 0x0000FFFF) {
-		case hkdf.TLS_AES_128_GCM_SHA256:
-		case hkdf.TLS_CHACHA20_POLY1305_SHA256:
+		case hkdf.TLS_AES_128_GCM_SHA256, hkdf.TLS_CHACHA20_POLY1305_SHA256:
 			transcript = crypto.SHA256.New()
 		case hkdf.TLS_AES_256_GCM_SHA384:
 			transcript = crypto.SHA384.New()


### PR DESCRIPTION
PR to fix TLSv1.3-related issues.

I use ecapture to hook `libssl` used by an NGINX server, not the client side `libssl`.
Then I found that neither the written key log file nor PcapNG with DSB could decrypt the TLS 1.3 traffic. 

Environment:

1. NGINX with OpenSSL 1.1.1n
2. Cipher suites: TLS_AES_256_GCM_SHA384
3. curl compiled with `USE_CURL_SSLKEYLOGFILE` enabled

Issues I found and fixed:

1. write `SERVER_HANDSHAKE_TRAFFIC_SECRET` instead of a second `CLIENT_HANDSHAKE_TRAFFIC_SECRET` to the key log file
2. uses Hash function found in cipher_id of the master key event in `expandLabel` function

After fixed the above issues, still couldn't decrypt the TLS 1.3 traffic. In key log file, client_randoms are the same for both key log file. But four values are all different.

Possible issues I found:

In OpenSSL 1.1.1d, a new pointer `peer_ciphers` was introduced in the `ssl_st` struct which may affect all offsets related to hashes and secrets?

I tried:

X-Macros from this [article](https://www.containiq.com/post/decrypting-ssl-at-scale-with-ebpf) was used to recalculate all offsets. But the program gave different offset for client_random in the `ssl3_state_st` struct. The current client_random offset should be correct, as it can be verified in the Client Hello message captured by `tcpdump`.

Result from the X-Macros program:

```c
ssl_offsets openssl_offset_269488367 = { 
  .ssl_session_st_master_key = 0x50,
  .ssl_session_st_master_key_length = 0x8,
  .ssl3_state_st_client_random = 0xb8,
  .ssl_st_early_secret = 0x13c,
  .ssl_st_handshake_secret = 0x17c,
  .ssl_st_master_secret = 0x1bc,
  .ssl_st_resumption_master_secret = 0x1fc,
  .ssl_st_client_finished_secret = 0x23c,
  .ssl_st_server_finished_secret = 0x27c,
  .ssl_st_server_finished_hash = 0x2bc,
  .ssl_st_handshake_traffic_hash = 0x2fc,
  .ssl_st_client_app_traffic_secret = 0x33c,
  .ssl_st_server_app_traffic_secret = 0x37c,
  .ssl_st_exporter_master_secret = 0x3bc,
}
```

I have no clue for now to make this function work as expected. Maybe it's strict to the environment or the designated cipher suite?

@cfc4n any suggestion?

