### PR TITLE
user/module : use const for SSL masterKey function hook.

### DIFF
--- a/user/module/const_androidgki.go
+++ b/user/module/const_androidgki.go
@@ -1,0 +1,13 @@
+//go:build androidgki
+// +build androidgki
+
+package module
+
+/*
+Copyright © 2022 CFC4N <cfc4n.cs@gmail.com>
+
+*/
+
+const (
+	PROBE_OPENSSL_MASTERKEY_FUNC = "SSL_do_handshake"
+)

--- a/user/module/const_linux.go
+++ b/user/module/const_linux.go
@@ -1,0 +1,13 @@
+//go:build !androidgki
+// +build !androidgki
+
+package module
+
+/*
+Copyright © 2022 CFC4N <cfc4n.cs@gmail.com>
+
+*/
+
+const (
+	PROBE_OPENSSL_MASTERKEY_FUNC = "SSL_write"
+)

--- a/user/module/probe_openssl_tc.go
+++ b/user/module/probe_openssl_tc.go
@@ -109,7 +109,7 @@ func (this *MOpenSSLProbe) setupManagersTC() error {
 			{
 				Section:          "uprobe/SSL_write_key",
 				EbpfFuncName:     "probe_ssl_master_key",
-				AttachToFuncName: "SSL_do_handshake", // SSL_do_handshake or SSL_write
+				AttachToFuncName: PROBE_OPENSSL_MASTERKEY_FUNC, // SSL_do_handshake or SSL_write
 				BinaryPath:       binaryPath,
 				UID:              "uprobe_ssl_master_key",
 			},


### PR DESCRIPTION
fixes:#212

1. SSL_do_handshake for Android.
2. SSL_write for Linux

`SSL_do_handshake` was null sometimes on Linux .

Signed-off-by: CFC4N <cfc4n.cs@gmail.com>