### PR TITLE
kern: rodata map not supported on kernel 4.19 or older

### DIFF
--- a/kern/common.h
+++ b/kern/common.h
@@ -31,12 +31,12 @@
 #define ETH_P_IP 0x0800 /* Internet Protocol packet        */
 #define SKB_MAX_DATA_SIZE 2048
 
-// alawyse, we used it in openssl_tc.h
-const volatile u32 target_port = 443;
 
-// Optional Target PID
 // .rodata section bug via : https://github.com/ehids/ecapture/issues/39
 #ifndef KERNEL_LESS_5_2
+// alawyse, we used it in openssl_tc.h
+const volatile u32 target_port = 443;
+// Optional Target PID
 const volatile u64 target_pid = 0;
 const volatile u64 target_uid = 0;
 const volatile int target_errno = BASH_ERRNO_DEFAULT;

--- a/kern/openssl_tc.h
+++ b/kern/openssl_tc.h
@@ -110,11 +110,12 @@ int capture_packets(struct __sk_buff *skb, bool is_ingress) {
     }
     struct tcphdr *tcp = (struct tcphdr *)(data_start + l4_hdr_off);
 
+#ifndef KERNEL_LESS_5_2
     if (tcp->source != bpf_htons(target_port) &&
         tcp->dest != bpf_htons(target_port)) {
         return TC_ACT_OK;
     }
-
+#endif
     //    debug_bpf_printk("capture_packets port : %d, dest port :%d\n",
     //    bpf_ntohs(tcp->source), bpf_ntohs(tcp->dest));
     // get the skb data event


### PR DESCRIPTION
fixes : #222

.rodata: map create: read- and write-only maps not supported

Signed-off-by: CFC4N <cfc4n.cs@gmail.com>