### PR TITLE
constant value has to be of type uint64 (#261)

### DIFF
--- a/kern/common.h
+++ b/kern/common.h
@@ -48,7 +48,7 @@
 // .rodata section bug via : https://github.com/ehids/ecapture/issues/39
 #ifndef KERNEL_LESS_5_2
 // alawyse, we used it in openssl_tc.h
-const volatile u32 target_port = 443;
+const volatile u64 target_port = 443;
 // Optional Target PID
 const volatile u64 target_pid = 0;
 const volatile u64 target_uid = 0;

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -181,7 +181,8 @@ func (this *Module) readEvents() error {
 		case e.Type() == ebpf.PerfEventArray:
 			this.perfEventReader(errChan, e)
 		default:
-			return fmt.Errorf("%s\tNot support mapType:%s , mapinfo:%s", this.child.Name(), e.Type().String(), e.String())
+			return fmt.Errorf("%s\tunsupported mapType:%s , mapinfo:%s",
+				this.child.Name(), e.Type().String(), e.String())
 		}
 	}
 

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -244,7 +244,7 @@ func (this *MOpenSSLProbe) constantEditor() []manager.ConstantEditor {
 		},
 		{
 			Name:  "target_port",
-			Value: uint32(this.conf.(*config.OpensslConfig).Port),
+			Value: uint64(this.conf.(*config.OpensslConfig).Port),
 		},
 	}
 


### PR DESCRIPTION
with the asm method, the constant value has to be of type uint64

Signed-off-by: CFC4N <cfc4n.cs@gmail.com>